### PR TITLE
Update extractor.py

### DIFF
--- a/musicnn/extractor.py
+++ b/musicnn/extractor.py
@@ -115,9 +115,9 @@ def extractor(file_name, model='MTT_musicnn', input_length=3, input_overlap=Fals
     
     # select model
     if 'MTT' in model:
-        labels = config.MTT_LABELS
+        labels = config.MTT_LABELS.copy()
     elif 'MSD' in model:
-        labels = config.MSD_LABELS
+        labels = config.MSD_LABELS.copy()
     num_classes = len(labels)
     
     if 'vgg' in model and input_length != 3:


### PR DESCRIPTION
There's a small bug, not sure exactly where. I describe the issue and proposed solution below.

In my program I call extractor() to get features and then top_tag() to get tags in a loop (once per song file). On second iteration of the loop, top_tag() fails on line 75, which contains the statement: print(' - ' + tags[tag_index]). The error is that a string cannot be concatenated with a list(). The cause being that somehow the variable containing the list of tags in configuration.py (either MTT_LABELS or MSD_LABELS depending on parameters) gets appended a list of top tags computed by top_tag(). 

This issue does not happen if I run top_tag() in a loop alone or extractor() alone, but when I run extractor() followed by top_tag(), on each iteration of the loop the MTT_LABELS or MSD_LABELS gets appended a list of topN_tags. 

The easy/shortcut solution is to take a copy of that list (in configuration.py) instead of a pointer to it.