### PR TITLE
Remove upper bound for Numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
     license='ISC',
     install_requires=['librosa>=0.7.0',
                       'tensorflow>=1.14',
-                      'numpy<1.17,>=1.14.5']
+                      'numpy>=1.14.5']
 )


### PR DESCRIPTION
I ran into legacy errors when there was an upper bound on NumPy, as later versions of Librosa require NP >= 17.

* Librosa `Version: 0.9.2`
* NumPy `Version: 1.23.3`
* Tensorflow `Version: 2.10.0`

```
The conflict is caused by:
    musicnn 0.0.1 depends on numpy<1.17 and >=1.14.5
    librosa 0.9.2 depends on numpy>=1.17.0
    musicnn 0.0.1 depends on numpy<1.17 and >=1.14.5
    librosa 0.9.1 depends on numpy>=1.17.0
    musicnn 0.0.1 depends on numpy<1.17 and >=1.14.5
    librosa 0.9.0 depends on numpy>=1.17.0
```

Thanks @carlthome for debugging